### PR TITLE
Fix for fatal error occurring when running the binary release.

### DIFF
--- a/src/electron/src/modules/settings.js
+++ b/src/electron/src/modules/settings.js
@@ -467,7 +467,7 @@ class Settings {
         delete this.payload.advanced.useWaifu
         delete this.payload.folders.masks
       } catch (err) {
-        console.error(err);
+        console.warn(err)
       }
     }
 

--- a/src/electron/src/modules/settings.js
+++ b/src/electron/src/modules/settings.js
@@ -462,9 +462,13 @@ class Settings {
           mode: 2,
         },
       })
-
-      delete this.payload.advanced.useWaifu
-      delete this.payload.folders.masks
+      // This throws on some Windows 10 systems.
+      try {
+        delete this.payload.advanced.useWaifu
+        delete this.payload.folders.masks
+      } catch (err) {
+        console.error(err);
+      }
     }
 
     this.save()


### PR DESCRIPTION
I get a 100% reproducible fatal error every  time I run the 1.5.0 RC1 or RC2 binary release. After running through the steps to run from source I got the same exact error. Tracked it down to this attempting to delete a path that apparently doesn't exist.

Here is the error I get everytime if I don't add the code to swallow the exception (seems like the path to the settings its trying to delete doesn't exist). Running on latest node, Windows 10 Pro.
![image](https://user-images.githubusercontent.com/424694/87239340-e5851f80-c3c2-11ea-86d7-15f0adde4693.png)
